### PR TITLE
Configured host to stop when the Android OnDestroyed event is called

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     # Install NuGet
     - name: Setup Nuget.exe
-      uses: warrenbuckley/Setup-Nuget@v1
+      uses: NuGet/setup-nuget@v1.0.5
 
     # Install .NET Core
     - name: Setup .NET Core
@@ -22,7 +22,7 @@ jobs:
 
     # Install MSBuild
     - name: Setup MSBuild
-      uses: warrenbuckley/Setup-MSBuild@v1
+      uses: microsoft/setup-msbuild@v1
 
     # Restore projects
     - name: Restore Hostly

--- a/src/Hostly/Internals/XamarinHost.cs
+++ b/src/Hostly/Internals/XamarinHost.cs
@@ -66,14 +66,14 @@ namespace Hostly.Internals
             // Initialise empty app event handlers to prevent null reference exceptions.
             _platform.OnCreated += (sender, args) => { };
             _platform.OnDeactivate += (sender, args) => { };
-            _platform.OnDestroyed += (sender, args) => { };
+            _platform.OnStopped += (sender, args) => { };
             _platform.OnEnterForeground += (sender, args) => { };
             _platform.OnPause += (sender, args) => { };
             _platform.OnResume += (sender, args) => { };
             _platform.OnStarted += (sender, args) => { };
 
             // Register host to stop when app on platform stops
-            _platform.OnStopped += async (sender, args) => await StopAsync();
+            _platform.OnDestroyed += async (sender, args) => await StopAsync();
 
             _platform.LoadApplication(_application);
             _applicationLifetime?.NotifyStarted();


### PR DESCRIPTION
Fixes #63

We should ideally stop the host on the Android `OnDestroyed` event rather than the `OnStopped` event. I had an issue opening a page with an implementation of `ChromeCustomTabs`. I assume this was because opening a page from the browser would call the `OnStopped` event which would stop the host and cause all sorts of issues.

Note: Also updated the Nuget and MSBuild GH actions to be the official supported ones